### PR TITLE
Add some useful (for me) options - only-column-names and auto-create-csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ By default, the first three lines of output will describe the columns: labels, n
 ./sas-convert/sas-convert -o <file.sas7bdat> [file.csv]
 ```
 
+By default, if you don't pass the second argument, the output is sent to stdout. If instead you'd like to save it to an automatically named file based on the name of the input file, the `--auto-create-csv` or `-a` option will save the output to my-filename.csv:
+```bash
+./sas-convert/sas-convert -a my-filename.sas7bdat
+```
+
 ### Build and run from source
 ```bash
 mvn package

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ By default, the first three lines of output will describe the columns: labels, n
 ./sas-convert/sas-convert -o <file.sas7bdat> [file.csv]
 ```
 
-By default, if you don't pass the second argument, the output is sent to stdout. If instead you'd like to save it to an automatically named file based on the name of the input file, the `--auto-create-csv` or `-a` option will save the output to my-filename.csv:
+By default, if you don't pass the second argument, the output is sent to stdout. If instead you'd like to save it to an automatically named file based on the name of the input file, the `--auto-create-csv` or `-a` option will save this output to my-filename.csv:
 ```bash
 ./sas-convert/sas-convert -a my-filename.sas7bdat
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Usage:
 ./sas-convert/sas-convert <file.sas7bdat> [file.csv]
 ```
 
+By default, the first three lines of output will describe the columns: labels, names, and formats, respecitively. To only output one line of header information containing just column names, use the `--only-column-names` or `-o` option:
+```bash
+./sas-convert/sas-convert -o <file.sas7bdat> [file.csv]
+```
+
 ### Build and run from source
 ```bash
 mvn package


### PR DESCRIPTION
Thanks for this program, it is useful. IMHO, it'd be a bit more useful with these two options :)

By default, the first three lines of output will describe the columns: labels, names, and formats, respecitively. To only output one line of header information containing just column names, use the `--only-column-names` or `-o` option:
```bash
./sas-convert/sas-convert -o <file.sas7bdat> [file.csv]
```

By default, if you don't pass the second argument, the output is sent to stdout. If instead you'd like to save it to an automatically named file based on the name of the input file, the `--auto-create-csv` or `-a` option will save this output to my-filename.csv:
```bash
./sas-convert/sas-convert -a my-filename.sas7bdat
```